### PR TITLE
fix(ModuleForRoot): arguments where not passed as a spread

### DIFF
--- a/dist/decorators/module/module.decorator.js
+++ b/dist/decorators/module/module.decorator.js
@@ -48,8 +48,8 @@ function Module(module) {
         }));
         if (original.forRoot) {
             const originalForRoot = constructorFunction.forRoot;
-            constructorFunction.forRoot = function (args) {
-                const result = originalForRoot(args);
+            constructorFunction.forRoot = function (...args) {
+                const result = originalForRoot(...args);
                 if (!result) {
                     throw new Error(`forRoot configuration inside ${constructorFunction.name} is returning undefined or null`);
                 }

--- a/dist/services/cache/cache-layer.service.js
+++ b/dist/services/cache/cache-layer.service.js
@@ -8,8 +8,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 var CacheService_1;
+Object.defineProperty(exports, "__esModule", { value: true });
 const rxjs_1 = require("rxjs");
 const operators_1 = require("rxjs/operators");
 const cache_layer_1 = require("./cache-layer");

--- a/dist/services/exit-handler/exit-handler.service.d.ts
+++ b/dist/services/exit-handler/exit-handler.service.d.ts
@@ -6,5 +6,5 @@ export declare class ExitHandlerService {
     private logger;
     init(): void;
     exitHandler(options: any, err: any): void;
-    onExitApp(events: Array<Signals>): Observable<{}>;
+    onExitApp(events: Array<Signals>): Observable<unknown>;
 }

--- a/dist/services/external-importer/external-importer.d.ts
+++ b/dist/services/external-importer/external-importer.d.ts
@@ -51,6 +51,6 @@ export declare class ExternalImporter {
     private combineDependencies;
     private writeFakeIndexIfMultiModule;
     downloadIpfsModule(config: ExternalImporterIpfsConfig): any;
-    downloadTypings(moduleLink: string, folder: string, fileName: string, config: ExternalImporterConfig): Observable<{}>;
+    downloadTypings(moduleLink: string, folder: string, fileName: string, config: ExternalImporterConfig): Observable<unknown>;
     importModule(config: ExternalImporterConfig, token: string, { folderOverride, waitUntil }?: any): Promise<any>;
 }

--- a/dist/services/file/file.service.d.ts
+++ b/dist/services/file/file.service.d.ts
@@ -1,12 +1,12 @@
 import { Observable } from 'rxjs';
 export declare class FileService {
     private logger;
-    writeFile(folder: string, fileName: any, moduleName: any, file: any): Observable<{}>;
+    writeFile(folder: string, fileName: any, moduleName: any, file: any): Observable<unknown>;
     writeFileAsync(folder: string, fileName: any, moduleName: any, file: any): Observable<string>;
     writeFileSync(folder: any, file: any): any;
     readFile(file: string): any;
     isPresent(path: string): boolean;
-    writeFileAsyncP(folder: any, fileName: any, content: any): Observable<{}>;
+    writeFileAsyncP(folder: any, fileName: any, content: any): Observable<unknown>;
     mkdirp(folder: any): Observable<boolean>;
     fileWalker(dir: string, exclude?: string): Observable<string[]>;
     private filewalker;

--- a/dist/services/npm-service/npm.service.d.ts
+++ b/dist/services/npm-service/npm.service.d.ts
@@ -8,5 +8,5 @@ export declare class NpmService {
     child: childProcess.ChildProcess;
     setPackages(packages: NpmPackageConfig[]): void;
     preparePackages(): void;
-    installPackages(): Promise<{}>;
+    installPackages(): Promise<unknown>;
 }

--- a/src/decorators/module/module.decorator.ts
+++ b/src/decorators/module/module.decorator.ts
@@ -59,8 +59,8 @@ export function Module<T, K extends keyof T>(module?: ModuleArguments<T, K>): Fu
             }));
         if (original.forRoot) {
             const originalForRoot = constructorFunction.forRoot;
-            constructorFunction.forRoot = function (args?: any) {
-                const result: ModuleWithServices = originalForRoot(args);
+            constructorFunction.forRoot = function (...args: any) {
+                const result: ModuleWithServices = originalForRoot(...args);
 
                 if (!result) {
                     throw new Error(`forRoot configuration inside ${constructorFunction.name} is returning undefined or null`);


### PR DESCRIPTION
### https://github.com/rxdi/core/issues/5

# Description

Introduces logic to pass rest of the parameters when calling `forRoot` method inside `public static` module